### PR TITLE
Add -h flag to brunnhilde terminal prompt

### DIFF
--- a/bitcurator/env/usr/local/bin/run-brunnhilde.sh
+++ b/bitcurator/env/usr/local/bin/run-brunnhilde.sh
@@ -13,6 +13,6 @@ set arg1 [lindex $argv 0]
 spawn -noecho bash
 expect "$ "
 send "cd ~/\n"
-send "brunnhilde.py\n"
+send "brunnhilde.py -h\n"
 interact
 exit


### PR DESCRIPTION
Hi. This very small PR modifies the Brunnhilde terminal prompt to run the -h flag, which may be helpful to first-time users. Thanks!